### PR TITLE
feat: merchandise suggested calendar-gap stays

### DIFF
--- a/doxyde-cli/src/bin/doxyde-multidb-migrate.rs
+++ b/doxyde-cli/src/bin/doxyde-multidb-migrate.rs
@@ -260,7 +260,7 @@ fn calculate_site_key(base_domain: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(base_domain.as_bytes());
     let hash = hasher.finalize();
-    hex::encode(&hash[..4])
+    hex::encode(hash.iter().take(4).copied().collect::<Vec<_>>())
 }
 
 /// Transform a database from single-site to multi-site format

--- a/doxyde-cli/src/main.rs
+++ b/doxyde-cli/src/main.rs
@@ -730,10 +730,22 @@ async fn migrate_images(domain: &str, dry_run: bool) -> Result<()> {
                             .ok_or_else(|| anyhow!("Component {} not found", comp_id))?;
 
                         let mut content = comp.content.clone();
-                        content["file_path"] = serde_json::json!(result.new_path.to_string_lossy());
-                        content["content_hash"] = serde_json::json!(result.content_hash);
+                        let obj = content.as_object_mut().ok_or_else(|| {
+                            anyhow!("Image component {} content is not an object", comp_id)
+                        })?;
+                        obj.insert(
+                            "file_path".to_string(),
+                            serde_json::json!(result.new_path.to_string_lossy()),
+                        );
+                        obj.insert(
+                            "content_hash".to_string(),
+                            serde_json::json!(result.content_hash),
+                        );
                         if let Some(ref tp) = result.thumb_path {
-                            content["thumb_file_path"] = serde_json::json!(tp.to_string_lossy());
+                            obj.insert(
+                                "thumb_file_path".to_string(),
+                                serde_json::json!(tp.to_string_lossy()),
+                            );
                         }
 
                         component_repo
@@ -927,7 +939,9 @@ async fn rewrite_image_paths(pool: &SqlitePool, site_dir: &Path, dry_run: bool) 
                 if new_path != *fp {
                     println!("  [{}] file_path: {} -> {}", id, fp, new_path);
                     if !dry_run {
-                        content["file_path"] = serde_json::json!(new_path);
+                        if let Some(obj) = content.as_object_mut() {
+                            obj.insert("file_path".to_string(), serde_json::json!(new_path));
+                        }
                     }
                     changed = true;
                 }
@@ -939,7 +953,9 @@ async fn rewrite_image_paths(pool: &SqlitePool, site_dir: &Path, dry_run: bool) 
                 if new_path != *tp {
                     println!("  [{}] thumb_file_path: {} -> {}", id, tp, new_path);
                     if !dry_run {
-                        content["thumb_file_path"] = serde_json::json!(new_path);
+                        if let Some(obj) = content.as_object_mut() {
+                            obj.insert("thumb_file_path".to_string(), serde_json::json!(new_path));
+                        }
                     }
                     changed = true;
                 }

--- a/doxyde-web/src/content.rs
+++ b/doxyde-web/src/content.rs
@@ -89,10 +89,9 @@ impl ContentPath {
         // Find the last segment that starts with '.'
         let parts: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
 
-        if let Some(last) = parts.last() {
+        if let Some((last, path_parts)) = parts.split_last() {
             if last.starts_with('.') {
                 // We have an action
-                let path_parts = &parts[..parts.len() - 1];
                 let path = if path_parts.is_empty() {
                     "/".to_string()
                 } else {

--- a/doxyde-web/src/db_middleware.rs
+++ b/doxyde-web/src/db_middleware.rs
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use axum::{
+    body::Body,
     extract::{FromRequestParts, Request, State},
     http::{request::Parts, StatusCode},
     middleware::Next,
@@ -77,20 +78,18 @@ pub async fn database_injection_middleware(
                 Err(e) => {
                     tracing::error!("Failed to get database pool for site '{}': {:?}", domain, e);
                     // Always fail fast to avoid data corruption
-                    return axum::response::Response::builder()
-                        .status(axum::http::StatusCode::INTERNAL_SERVER_ERROR)
-                        .body(axum::body::Body::from("Database initialization failed"))
-                        .unwrap();
+                    let mut response = Response::new(Body::from("Database initialization failed"));
+                    *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                    return response;
                 }
             }
         }
     } else {
         tracing::error!("No site context found in request");
         // Fail fast - no fallback
-        return axum::response::Response::builder()
-            .status(axum::http::StatusCode::INTERNAL_SERVER_ERROR)
-            .body(axum::body::Body::from("Site context missing"))
-            .unwrap();
+        let mut response = Response::new(Body::from("Site context missing"));
+        *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+        return response;
     }
 
     // Continue with the request

--- a/doxyde-web/src/domain_utils.rs
+++ b/doxyde-web/src/domain_utils.rs
@@ -19,11 +19,7 @@ pub fn extract_base_domain(domain: &str) -> String {
     let domain_no_port = domain.split(':').next().unwrap_or(domain);
 
     // Handle email-like domains by taking everything after @
-    let domain_no_prefix = if let Some(at_pos) = domain_no_port.rfind('@') {
-        &domain_no_port[at_pos + 1..]
-    } else {
-        domain_no_port
-    };
+    let domain_no_prefix = domain_no_port.rsplit('@').next().unwrap_or(domain_no_port);
 
     // Convert to lowercase for consistency
     let domain_lower = domain_no_prefix.to_lowercase();
@@ -33,13 +29,14 @@ pub fn extract_base_domain(domain: &str) -> String {
 
     // If we have at least 2 parts, take the last 2 as the base domain
     // This handles most common cases like example.com, example.org, etc.
-    if parts.len() >= 2 {
-        let base = format!("{}.{}", parts[parts.len() - 2], parts[parts.len() - 1]);
-        base
-    } else {
-        // For single-part domains (like "localhost"), return as-is
-        domain_lower
+    if let Some((tld, rest)) = parts.split_last() {
+        if let Some(domain_name) = rest.last() {
+            return format!("{domain_name}.{tld}");
+        }
     }
+
+    // For single-part domains (like "localhost"), return as-is
+    domain_lower
 }
 
 /// Resolves a site directory path from a base path and domain name.

--- a/doxyde-web/src/handlers/booking.rs
+++ b/doxyde-web/src/handlers/booking.rs
@@ -81,6 +81,19 @@ fn is_past_date(date: &str) -> bool {
     }
 }
 
+/// Compute default search dates: tomorrow and day after tomorrow in Mauritius time.
+fn default_stay_dates() -> (String, String) {
+    let today = chrono::Utc::now()
+        .with_timezone(&chrono_tz::Indian::Mauritius)
+        .date_naive();
+    let tomorrow = today + chrono::Duration::days(1);
+    let day_after = today + chrono::Duration::days(2);
+    (
+        tomorrow.format("%Y-%m-%d").to_string(),
+        day_after.format("%Y-%m-%d").to_string(),
+    )
+}
+
 /// 302 to the site home. Used when a deep-link targets a past date (e.g. an expired
 /// last-minute ad link) so visitors land on the homepage, not an empty/broken form.
 fn redirect_home() -> Response {
@@ -285,13 +298,26 @@ pub async fn stay_handler(
     if let Some(ref utm) = utm {
         tracing::info!(target: "attribution", host = %host, path = "/.stay", utm = %utm);
     }
-    insert_attribution_context(&mut context, &Attribution::from(&q));
+    let attr = Attribution::from(&q);
+    insert_attribution_context(&mut context, &attr);
 
     let adults = q.adults.unwrap_or(2).max(1);
     let children = q.children.unwrap_or(0).max(0);
     let infants = q.infants.unwrap_or(0).max(0);
-    context.insert("q_from", &q.from);
-    context.insert("q_to", &q.to);
+
+    let (default_from, default_to) = default_stay_dates();
+    let visible_from = q
+        .from
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(&default_from);
+    let visible_to =
+        q.to.as_deref()
+            .filter(|s| !s.is_empty())
+            .unwrap_or(&default_to);
+
+    context.insert("q_from", visible_from);
+    context.insert("q_to", visible_to);
     context.insert("q_adults", &adults);
     context.insert("q_children", &children);
     context.insert("q_infants", &infants);
@@ -309,21 +335,92 @@ pub async fn stay_handler(
         return Ok(render(&state, "booking/stay.html", &context)?.into_response());
     }
 
-    let (from, to) = match (q.from.as_deref(), q.to.as_deref()) {
-        (Some(f), Some(t)) if !f.is_empty() && !t.is_empty() => (f, t),
-        _ => {
-            if json {
-                return Ok(axum::Json(serde_json::json!({
-                    "status": "ok",
-                    "results": Vec::<serde_json::Value>::new(),
-                    "secondary_results": Vec::<serde_json::Value>::new(),
-                    "hint": "provide from/to dates"
-                }))
-                .into_response());
-            }
-            return Ok(render(&state, "booking/stay.html", &context)?.into_response());
+    let has_dates = matches!(
+        (q.from.as_deref(), q.to.as_deref()),
+        (Some(f), Some(t)) if !f.is_empty() && !t.is_empty()
+    );
+    let has_partial_dates = !has_dates
+        && [q.from.as_deref(), q.to.as_deref()]
+            .into_iter()
+            .flatten()
+            .any(|value| !value.is_empty());
+
+    let all = repo.list_listings().await.unwrap_or_default();
+    let client = SejoursClient::new(&config.service_url, &config.service_secret);
+
+    if has_partial_dates {
+        if json {
+            return Ok(axum::Json(serde_json::json!({
+                "status": "ok",
+                "results": Vec::<serde_json::Value>::new(),
+                "secondary_results": Vec::<serde_json::Value>::new(),
+                "hint": "provide from/to dates"
+            }))
+            .into_response());
         }
-    };
+        return Ok(render(&state, "booking/stay.html", &context)?.into_response());
+    }
+
+    if !has_dates {
+        let all_ids: Vec<i64> = all.iter().map(|l| l.listing_id).collect();
+        let mut suggestions_json = Vec::new();
+        let mut degraded = false;
+        let mut hero_image: Option<String> = None;
+
+        match client.suggested_stays(&all_ids, adults, children).await {
+            Ok(sug_resp) => {
+                degraded = sug_resp.degraded;
+                let utm_qs = attribution_query(&attr);
+                hero_image = sug_resp.suggestions.first().and_then(|s| s.image.clone());
+
+                suggestions_json = sug_resp
+                    .suggestions
+                    .iter()
+                    .map(|s| {
+                        let mut val = serde_json::to_value(s).unwrap_or_default();
+                        let s_url = format!(
+                            "/.stay?from={}&to={}&adults={}&children={}&infants={}{}",
+                            s.check_in, s.check_out, adults, children, infants, utm_qs
+                        );
+                        if let Some(obj) = val.as_object_mut() {
+                            obj.insert("search_url".to_string(), serde_json::json!(s_url));
+                        }
+                        val
+                    })
+                    .collect();
+            }
+            Err(error) => {
+                tracing::warn!(
+                    "sejours-api /v1/suggested-stays call failed on no-date search: {:?}",
+                    error
+                );
+            }
+        }
+
+        context.insert("suggestions", &suggestions_json);
+        context.insert("suggested_degraded", &degraded);
+        if let Some(ref img) = hero_image {
+            context.insert("hero_image", img);
+        }
+
+        if json {
+            return Ok(axum::Json(serde_json::json!({
+                "status": "ok",
+                "results": Vec::<serde_json::Value>::new(),
+                "secondary_results": Vec::<serde_json::Value>::new(),
+                "suggestions": suggestions_json,
+                "degraded": degraded,
+                "hint": "provide from/to dates"
+            }))
+            .into_response());
+        }
+
+        return Ok(render(&state, "booking/stay.html", &context)?.into_response());
+    }
+
+    let from = q.from.as_deref().unwrap_or_default();
+    let to = q.to.as_deref().unwrap_or_default();
+
     if to <= from {
         if json {
             return Ok(json_error("invalid_dates"));
@@ -339,7 +436,6 @@ pub async fn stay_handler(
     }
     context.insert("searched", &true);
 
-    let all = repo.list_listings().await.unwrap_or_default();
     let page_map: HashMap<i64, String> = all
         .iter()
         .filter_map(|l| l.page_path.clone().map(|p| (l.listing_id, p)))
@@ -354,7 +450,6 @@ pub async fn stay_handler(
         .filter(|l| l.role == "secondary")
         .map(|l| l.listing_id)
         .collect();
-    let client = SejoursClient::new(&config.service_url, &config.service_secret);
 
     let resp = match client
         .availability(from, to, adults, children, infants, &primary_ids)

--- a/doxyde-web/src/handlers/delete_page.rs
+++ b/doxyde-web/src/handlers/delete_page.rs
@@ -85,7 +85,7 @@ pub async fn delete_page_handler(
     let current_path = if breadcrumb.len() <= 1 {
         "/".to_string()
     } else {
-        let path_parts: Vec<&str> = breadcrumb[1..].iter().map(|p| p.slug.as_str()).collect();
+        let path_parts: Vec<&str> = breadcrumb.iter().skip(1).map(|p| p.slug.as_str()).collect();
         format!("/{}", path_parts.join("/"))
     };
 
@@ -179,7 +179,7 @@ pub async fn do_delete_page_handler(
     let parent_url = if breadcrumb.len() <= 1 {
         "/".to_string()
     } else {
-        let path_parts: Vec<&str> = breadcrumb[1..].iter().map(|p| p.slug.as_str()).collect();
+        let path_parts: Vec<&str> = breadcrumb.iter().skip(1).map(|p| p.slug.as_str()).collect();
         format!("/{}/", path_parts.join("/"))
     };
 

--- a/doxyde-web/src/handlers/edit.rs
+++ b/doxyde-web/src/handlers/edit.rs
@@ -191,7 +191,12 @@ pub async fn edit_page_content_handler(
         let url = if i == 0 {
             "/".to_string()
         } else {
-            let path_parts: Vec<&str> = breadcrumb[1..=i].iter().map(|p| p.slug.as_str()).collect();
+            let path_parts: Vec<&str> = breadcrumb
+                .iter()
+                .skip(1)
+                .take(i)
+                .map(|p| p.slug.as_str())
+                .collect();
             format!("/{}", path_parts.join("/"))
         };
 
@@ -205,7 +210,7 @@ pub async fn edit_page_content_handler(
     let current_path = if page.parent_page_id.is_none() {
         "/".to_string()
     } else {
-        let path_parts: Vec<&str> = breadcrumb[1..].iter().map(|p| p.slug.as_str()).collect();
+        let path_parts: Vec<&str> = breadcrumb.iter().skip(1).map(|p| p.slug.as_str()).collect();
         format!("/{}", path_parts.join("/"))
     };
 
@@ -476,7 +481,7 @@ async fn build_page_path(
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    let path_parts: Vec<&str> = breadcrumb[1..].iter().map(|p| p.slug.as_str()).collect();
+    let path_parts: Vec<&str> = breadcrumb.iter().skip(1).map(|p| p.slug.as_str()).collect();
 
     Ok(format!("/{}", path_parts.join("/")))
 }
@@ -509,7 +514,12 @@ pub async fn new_page_handler(
         let url = if i == 0 {
             "/".to_string()
         } else {
-            let path_parts: Vec<&str> = breadcrumb[1..=i].iter().map(|p| p.slug.as_str()).collect();
+            let path_parts: Vec<&str> = breadcrumb
+                .iter()
+                .skip(1)
+                .take(i)
+                .map(|p| p.slug.as_str())
+                .collect();
             format!("/{}", path_parts.join("/"))
         };
 
@@ -523,7 +533,7 @@ pub async fn new_page_handler(
     let current_path = if page.parent_page_id.is_none() {
         "/".to_string()
     } else {
-        let path_parts: Vec<&str> = breadcrumb[1..].iter().map(|p| p.slug.as_str()).collect();
+        let path_parts: Vec<&str> = breadcrumb.iter().skip(1).map(|p| p.slug.as_str()).collect();
         format!("/{}", path_parts.join("/"))
     };
 
@@ -814,16 +824,23 @@ pub async fn save_draft_handler(
     }
 
     // Update each submitted component
-    for i in 0..form.component_ids.len() {
-        let component_id = form.component_ids[i];
-        let component_type = &form.component_types[i];
-        let title = if form.component_titles[i].is_empty() {
+    let zipped = form
+        .component_ids
+        .iter()
+        .zip(&form.component_types)
+        .zip(&form.component_titles)
+        .zip(&form.component_templates)
+        .zip(&form.component_contents);
+
+    for (i, ((((component_id, component_type), component_title), template), content_str)) in
+        zipped.enumerate()
+    {
+        let component_id = *component_id;
+        let title = if component_title.is_empty() {
             None
         } else {
-            Some(form.component_titles[i].clone())
+            Some(component_title.clone())
         };
-        let template = &form.component_templates[i];
-        let content_str = &form.component_contents[i];
 
         tracing::info!(
             "=== Processing component {} (index: {}) ===",

--- a/doxyde-web/src/handlers/image_upload.rs
+++ b/doxyde-web/src/handlers/image_upload.rs
@@ -228,7 +228,9 @@ pub async fn upload_image_handler(
         "height": metadata.height,
     });
     if let Some(ref thumb_rel) = rel_thumb {
-        content["thumb_file_path"] = json!(thumb_rel);
+        if let Some(obj) = content.as_object_mut() {
+            obj.insert("thumb_file_path".to_string(), json!(thumb_rel));
+        }
     }
 
     // Create new component
@@ -352,7 +354,9 @@ pub async fn upload_image_ajax_handler(
         "height": metadata.height,
     });
     if let Some(ref thumb_rel) = rel_thumb {
-        response["thumb_file_path"] = json!(thumb_rel);
+        if let Some(obj) = response.as_object_mut() {
+            obj.insert("thumb_file_path".to_string(), json!(thumb_rel));
+        }
     }
 
     Ok(Json(response).into_response())
@@ -537,7 +541,9 @@ pub async fn upload_component_image_handler(
         "height": metadata.height,
     });
     if let Some(ref thumb_rel) = rel_thumb {
-        content["thumb_file_path"] = json!(thumb_rel);
+        if let Some(obj) = content.as_object_mut() {
+            obj.insert("thumb_file_path".to_string(), json!(thumb_rel));
+        }
     }
 
     // Update the component
@@ -555,8 +561,8 @@ pub async fn upload_component_image_handler(
     let mut response = json!({
         "success": true,
         "slug": slug,
-        "title": content["title"],
-        "description": content["description"],
+        "title": content.get("title").cloned().unwrap_or(serde_json::Value::Null),
+        "description": content.get("description").cloned().unwrap_or(serde_json::Value::Null),
         "format": metadata.format.extension(),
         "file_path": rel_path,
         "content_hash": saved.content_hash,
@@ -567,7 +573,9 @@ pub async fn upload_component_image_handler(
         "height": metadata.height,
     });
     if let Some(ref thumb_rel) = rel_thumb {
-        response["thumb_file_path"] = json!(thumb_rel);
+        if let Some(obj) = response.as_object_mut() {
+            obj.insert("thumb_file_path".to_string(), json!(thumb_rel));
+        }
     }
 
     Ok(Json(response).into_response())

--- a/doxyde-web/src/handlers/move_page.rs
+++ b/doxyde-web/src/handlers/move_page.rs
@@ -94,7 +94,8 @@ pub async fn move_page_handler(
         let path = if breadcrumb.len() <= 1 {
             "/".to_string()
         } else {
-            let path_parts: Vec<&str> = breadcrumb[1..].iter().map(|p| p.slug.as_str()).collect();
+            let path_parts: Vec<&str> =
+                breadcrumb.iter().skip(1).map(|p| p.slug.as_str()).collect();
             format!("/{}", path_parts.join("/"))
         };
 
@@ -131,7 +132,7 @@ pub async fn move_page_handler(
     let current_path = if breadcrumb.len() <= 1 {
         "/".to_string()
     } else {
-        let path_parts: Vec<&str> = breadcrumb[1..].iter().map(|p| p.slug.as_str()).collect();
+        let path_parts: Vec<&str> = breadcrumb.iter().skip(1).map(|p| p.slug.as_str()).collect();
         format!("/{}", path_parts.join("/"))
     };
 
@@ -250,7 +251,7 @@ pub async fn do_move_page_handler(
         format!("/{}", page.slug)
     } else {
         // Build path from breadcrumb
-        let path_parts: Vec<&str> = breadcrumb[1..].iter().map(|p| p.slug.as_str()).collect();
+        let path_parts: Vec<&str> = breadcrumb.iter().skip(1).map(|p| p.slug.as_str()).collect();
         format!("/{}/{}", path_parts.join("/"), page.slug)
     };
 

--- a/doxyde-web/src/handlers/pages.rs
+++ b/doxyde-web/src/handlers/pages.rs
@@ -220,8 +220,9 @@ pub async fn render_page(
                     let child_url = if child_breadcrumb.len() <= 1 {
                         "/".to_string()
                     } else {
-                        let path_parts: Vec<&str> = child_breadcrumb[1..]
+                        let path_parts: Vec<&str> = child_breadcrumb
                             .iter()
+                            .skip(1)
                             .map(|p| p.slug.as_str())
                             .collect();
                         format!("/{}", path_parts.join("/"))
@@ -273,7 +274,9 @@ pub async fn render_page(
                 }
 
                 // Inject pages data into component content
-                config["pages"] = serde_json::json!(pages_data);
+                if let Some(obj) = config.as_object_mut() {
+                    obj.insert("pages".to_string(), serde_json::json!(pages_data));
+                }
                 component.content = config;
             }
         }
@@ -298,7 +301,12 @@ pub async fn render_page(
         let url = if i == 0 {
             "/".to_string()
         } else {
-            let path_parts: Vec<&str> = breadcrumb[1..=i].iter().map(|p| p.slug.as_str()).collect();
+            let path_parts: Vec<&str> = breadcrumb
+                .iter()
+                .skip(1)
+                .take(i)
+                .map(|p| p.slug.as_str())
+                .collect();
             format!("/{}", path_parts.join("/"))
         };
 
@@ -313,7 +321,7 @@ pub async fn render_page(
         "/".to_string()
     } else {
         // Build current page path from breadcrumb (excluding root)
-        let path_parts: Vec<&str> = breadcrumb[1..].iter().map(|p| p.slug.as_str()).collect();
+        let path_parts: Vec<&str> = breadcrumb.iter().skip(1).map(|p| p.slug.as_str()).collect();
         format!("/{}", path_parts.join("/"))
     };
 
@@ -353,8 +361,12 @@ pub async fn render_page(
                     format!("/{}", child.slug)
                 } else {
                     // Build path from breadcrumb up to current level
-                    let path_parts: Vec<&str> =
-                        breadcrumb[1..=i].iter().map(|p| p.slug.as_str()).collect();
+                    let path_parts: Vec<&str> = breadcrumb
+                        .iter()
+                        .skip(1)
+                        .take(i)
+                        .map(|p| p.slug.as_str())
+                        .collect();
                     format!("/{}/{}", path_parts.join("/"), child.slug)
                 };
 

--- a/doxyde-web/src/handlers/properties.rs
+++ b/doxyde-web/src/handlers/properties.rs
@@ -75,7 +75,12 @@ pub async fn page_properties_handler(
         let url = if i == 0 {
             "/".to_string()
         } else {
-            let path_parts: Vec<&str> = breadcrumb[1..=i].iter().map(|p| p.slug.as_str()).collect();
+            let path_parts: Vec<&str> = breadcrumb
+                .iter()
+                .skip(1)
+                .take(i)
+                .map(|p| p.slug.as_str())
+                .collect();
             format!("/{}", path_parts.join("/"))
         };
 
@@ -89,7 +94,7 @@ pub async fn page_properties_handler(
     let current_path = if page.parent_page_id.is_none() {
         "/".to_string()
     } else {
-        let path_parts: Vec<&str> = breadcrumb[1..].iter().map(|p| p.slug.as_str()).collect();
+        let path_parts: Vec<&str> = breadcrumb.iter().skip(1).map(|p| p.slug.as_str()).collect();
         format!("/{}", path_parts.join("/"))
     };
 
@@ -250,7 +255,7 @@ pub async fn update_page_properties_handler(
                 StatusCode::INTERNAL_SERVER_ERROR
             })?;
 
-        let path_parts: Vec<&str> = breadcrumb[1..].iter().map(|p| p.slug.as_str()).collect();
+        let path_parts: Vec<&str> = breadcrumb.iter().skip(1).map(|p| p.slug.as_str()).collect();
         format!("/{}", path_parts.join("/"))
     };
 

--- a/doxyde-web/src/rate_limit.rs
+++ b/doxyde-web/src/rate_limit.rs
@@ -20,7 +20,7 @@ pub fn create_login_rate_limiter(max_attempts: u32) -> SharedRateLimiter {
         Some(n) => Quota::per_minute(n),
         None => {
             // If zero is passed, default to 1 to avoid panic
-            Quota::per_minute(NonZeroU32::new(1).unwrap())
+            Quota::per_minute(NonZeroU32::MIN)
         }
     };
     Arc::new(RateLimiter::direct(quota))
@@ -32,7 +32,7 @@ pub fn create_api_rate_limiter(max_requests: u32) -> SharedRateLimiter {
         Some(n) => Quota::per_minute(n),
         None => {
             // If zero is passed, default to 1 to avoid panic
-            Quota::per_minute(NonZeroU32::new(1).unwrap())
+            Quota::per_minute(NonZeroU32::MIN)
         }
     };
     Arc::new(RateLimiter::direct(quota))

--- a/doxyde-web/src/rmcp/handlers.rs
+++ b/doxyde-web/src/rmcp/handlers.rs
@@ -114,7 +114,9 @@ pub async fn handle_http(
         // Only include id if it exists and is not null
         if let Some(id) = &request_id {
             if !id.is_null() {
-                response["id"] = id.clone();
+                if let Some(obj) = response.as_object_mut() {
+                    obj.insert("id".to_string(), id.clone());
+                }
             }
         }
 

--- a/doxyde-web/src/routes.rs
+++ b/doxyde-web/src/routes.rs
@@ -17,7 +17,7 @@
 use crate::{
     attribution::attribution_capture_middleware,
     auth::CurrentUser,
-    configuration::Configuration,
+    configuration::{defaults, Configuration},
     content,
     db_middleware::{database_injection_middleware, SiteDatabase},
     debug_middleware::debug_form_middleware,
@@ -51,8 +51,20 @@ pub fn create_router(state: AppState) -> Router {
     let max_upload_size = state.config.max_upload_size;
 
     // Load the configuration to get security headers config
-    let config = Configuration::load().expect("Failed to load configuration");
-    let headers_middleware = create_security_headers_middleware(config.security.headers);
+    let headers_config = Configuration::load()
+        .map(|c| c.security.headers)
+        .unwrap_or_else(|_| crate::configuration::HeadersConfig {
+            enable_hsts: true,
+            enable_csp: true,
+            enable_frame_options: true,
+            enable_content_type_options: true,
+            csp_content: defaults::default_csp_content(),
+            hsts_content: defaults::default_hsts_content(),
+            frame_options_content: defaults::default_frame_options_content(),
+            referrer_policy: defaults::default_referrer_policy(),
+            permissions_policy: defaults::default_permissions_policy(),
+        });
+    let headers_middleware = create_security_headers_middleware(headers_config);
 
     Router::new()
         // Health check

--- a/doxyde-web/src/services/sejours_client.rs
+++ b/doxyde-web/src/services/sejours_client.rs
@@ -155,6 +155,33 @@ pub struct CalendarResponse {
     pub blocked: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SuggestedStay {
+    pub listing_id: i64,
+    pub listing_name: String,
+    pub check_in: String,
+    pub check_out: String,
+    pub nights: i64,
+    #[serde(default)]
+    pub price_total: Option<f64>,
+    #[serde(default)]
+    pub currency_code: Option<String>,
+    #[serde(default)]
+    pub image: Option<String>,
+    #[serde(default)]
+    pub person_capacity: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SuggestedStaysResponse {
+    #[serde(default)]
+    pub suggestions: Vec<SuggestedStay>,
+    #[serde(default)]
+    pub generated_at: String,
+    #[serde(default)]
+    pub degraded: bool,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct Contact {
     pub first_name: String,
@@ -225,6 +252,32 @@ impl SejoursClient {
             .send()
             .await
             .context("sejours-api /v1/availability request failed")?;
+        Self::json(resp).await
+    }
+
+    pub async fn suggested_stays(
+        &self,
+        listing_ids: &[i64],
+        adults: i64,
+        children: i64,
+    ) -> Result<SuggestedStaysResponse> {
+        let body = serde_json::json!({
+            "listing_ids": listing_ids,
+            "horizon_days": 30,
+            "min_nights": 1,
+            "max_nights": 7,
+            "limit": 6,
+            "adults": adults,
+            "children": children,
+        });
+        let resp = self
+            .client
+            .post(self.url("/v1/suggested-stays"))
+            .header(SECRET_HEADER, &self.secret)
+            .json(&body)
+            .send()
+            .await
+            .context("sejours-api /v1/suggested-stays request failed")?;
         Self::json(resp).await
     }
 

--- a/doxyde-web/src/services/translation.rs
+++ b/doxyde-web/src/services/translation.rs
@@ -63,7 +63,10 @@ pub async fn translate_batch_sync_bounded(
     }
 
     if !miss_idx.is_empty() {
-        let miss_refs: Vec<&str> = miss_idx.iter().map(|&i| items[i].as_str()).collect();
+        let miss_refs: Vec<&str> = miss_idx
+            .iter()
+            .filter_map(|&i| items.get(i).map(|s| s.as_str()))
+            .collect();
         match tokio::time::timeout(
             timeout,
             state
@@ -73,10 +76,11 @@ pub async fn translate_batch_sync_bounded(
         .await
         {
             Ok(Ok(results)) if results.len() == miss_idx.len() => {
-                for (k, res) in results.into_iter().enumerate() {
-                    let idx = miss_idx[k];
-                    store_success(pool, lang, &miss_hashes[k], &res.translated).await;
-                    out[idx] = Some(res.translated);
+                for ((res, &idx), hash) in results.into_iter().zip(&miss_idx).zip(&miss_hashes) {
+                    store_success(pool, lang, hash, &res.translated).await;
+                    if let Some(slot) = out.get_mut(idx) {
+                        *slot = Some(res.translated);
+                    }
                 }
             }
             Ok(Ok(_)) => {
@@ -97,7 +101,7 @@ pub async fn translate_batch_sync_bounded(
     // Assemble results. Any string still unresolved (timeout/error) is served as
     // source now and enqueued for deferred translation so the next crawl is warm.
     let mut result = Vec::with_capacity(items.len());
-    for (i, slot) in out.into_iter().enumerate() {
+    for (item, slot) in items.iter().zip(out) {
         match slot {
             Some(t) => result.push(t),
             None => {
@@ -106,7 +110,7 @@ pub async fn translate_batch_sync_bounded(
                     &state.translation.in_flight,
                     &state.translation.tx,
                     site_key,
-                    &items[i],
+                    item,
                     lang,
                     context,
                 )

--- a/doxyde-web/src/site_resolver.rs
+++ b/doxyde-web/src/site_resolver.rs
@@ -131,10 +131,9 @@ pub async fn site_resolver_middleware(
         Ok(path) => path,
         Err(e) => {
             tracing::error!("Failed to get sites directory: {:?}", e);
-            return Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(Body::from("Site configuration error"))
-                .unwrap();
+            let mut response = Response::new(Body::from("Site configuration error"));
+            *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+            return response;
         }
     };
 

--- a/doxyde-web/src/test_helpers.rs
+++ b/doxyde-web/src/test_helpers.rs
@@ -401,7 +401,10 @@ pub async fn create_test_session(
     let session = Session::new(user_id);
 
     session_repo.create(&session).await?;
-    let session = session_repo.find_by_id(&session.id).await?.unwrap();
+    let session = session_repo
+        .find_by_id(&session.id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Created session not found"))?;
 
     Ok(session)
 }

--- a/doxyde-web/src/ui_catalog.rs
+++ b/doxyde-web/src/ui_catalog.rs
@@ -26,6 +26,8 @@ pub const UI_LABELS: &[(&str, &str)] = &[
     ("booking.show_all_photos", "Show all photos"),
     // Search results + booking flow (lot 2)
     ("booking.results_title", "Available stays"),
+    ("booking.suggested_title", "Suggested stays"),
+    ("booking.next_availability_title", "Next availability"),
     ("booking.no_results", "No availability for these dates. Try different dates."),
     ("booking.sister_house", "Also available at our sister house"),
     ("booking.multi_stay_note", "Combination of stays — each leg is booked separately."),

--- a/doxyde-web/src/uploads.rs
+++ b/doxyde-web/src/uploads.rs
@@ -90,7 +90,10 @@ impl ImageFormat {
             Ok(ImageFormat::Png)
         } else if data.starts_with(GIF_MAGIC) {
             Ok(ImageFormat::Gif)
-        } else if data.starts_with(WEBP_MAGIC) && data.len() > 12 && &data[8..12] == b"WEBP" {
+        } else if data.starts_with(WEBP_MAGIC)
+            && data.len() > 12
+            && data.get(8..12) == Some(b"WEBP")
+        {
             Ok(ImageFormat::Webp)
         } else if data.starts_with(SVG_MAGIC) || data.starts_with(SVG_MAGIC_ALT) {
             Ok(ImageFormat::Svg)
@@ -217,7 +220,7 @@ pub fn is_dangerous_filename(filename: &str) -> bool {
     }
 
     // Check each extension part
-    for ext in &parts[1..] {
+    for ext in parts.iter().skip(1) {
         if DANGEROUS_EXTENSIONS.contains(ext) {
             return true;
         }
@@ -227,7 +230,7 @@ pub fn is_dangerous_filename(filename: &str) -> bool {
     // e.g., .php.jpg, .exe.txt
     if parts.len() > 2 {
         // Has double extension
-        for ext in &parts[1..parts.len() - 1] {
+        for ext in parts.iter().skip(1).take(parts.len().saturating_sub(2)) {
             if DANGEROUS_EXTENSIONS.contains(ext) {
                 // Dangerous extension hidden by another extension
                 return true;

--- a/doxyde-web/tests/booking_json_tests.rs
+++ b/doxyde-web/tests/booking_json_tests.rs
@@ -457,3 +457,352 @@ async fn test_book_json_not_configured() {
     assert_eq!(json_body["status"], "error");
     assert_eq!(json_body["code"], "not_configured");
 }
+
+async fn setup_test_with_real_templates(
+) -> (TestServer, sqlx::SqlitePool, MockServer, tempfile::TempDir) {
+    let mock_server = MockServer::start().await;
+    let temp_dir = tempfile::TempDir::new().expect("Failed to create temp dir");
+    let temp_path = temp_dir.path().to_string_lossy().to_string();
+
+    let mut state = doxyde_web::test_helpers::create_test_app_state()
+        .await
+        .expect("Failed to create test app state");
+    state.config.sites_directory = temp_path.clone();
+
+    let base_path = std::path::PathBuf::from(&temp_path);
+    let context = doxyde_web::site_resolver::SiteContext::new("test.local".to_string(), &base_path);
+    let pool = state
+        .db_router
+        .get_pool(&context)
+        .await
+        .expect("Failed to get pool");
+
+    sqlx::query("UPDATE booking_config SET service_url = ?, service_secret = ? WHERE id = 1")
+        .bind(mock_server.uri())
+        .bind("test-secret")
+        .execute(&pool)
+        .await
+        .expect("Failed to update booking config");
+
+    sqlx::query(
+        "INSERT INTO booking_listing (listing_id, role, position, page_path) VALUES (?, ?, ?, ?)",
+    )
+    .bind(123)
+    .bind("primary")
+    .bind(0)
+    .bind("/stars")
+    .execute(&pool)
+    .await
+    .expect("Failed to insert booking listing");
+
+    state.templates = doxyde_web::templates::init_templates("../templates", false)
+        .expect("Failed to initialize templates");
+
+    let app = create_router(state);
+    let server = TestServer::new(app).expect("Failed to create test server");
+
+    (server, pool, mock_server, temp_dir)
+}
+
+#[tokio::test]
+async fn test_suggested_stays_no_date_calls_api_and_renders_module() {
+    let (server, pool, mock_server, _temp_dir) = setup_test_with_real_templates().await;
+
+    sqlx::query(
+        "INSERT INTO booking_listing (listing_id, role, position, page_path) VALUES (?, ?, ?, ?)",
+    )
+    .bind(456)
+    .bind("secondary")
+    .bind(1)
+    .bind("/villa")
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let mock_response = json!({
+        "suggestions": [
+            {
+                "listing_id": 123,
+                "listing_name": "Sunset Villa",
+                "check_in": "2099-08-01",
+                "check_out": "2099-08-04",
+                "nights": 3,
+                "price_total": 350.0,
+                "currency_code": "EUR",
+                "image": "https://example.com/sunset.jpg",
+                "person_capacity": 4
+            }
+        ],
+        "degraded": false
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/v1/suggested-stays"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(mock_response))
+        .mount(&mock_server)
+        .await;
+
+    let response = server.get("/.stay").add_header("Host", "test.local").await;
+
+    response.assert_status(StatusCode::OK);
+    let html = response.text();
+    assert!(html.contains("Suggested stays"));
+    assert!(html.contains("Sunset Villa"));
+    assert!(html.contains("2099-08-01 → 2099-08-04"));
+    assert!(html.contains("350 EUR"));
+    assert!(
+        html.contains("https:&#x2F;&#x2F;example.com&#x2F;sunset.jpg"),
+        "rendered HTML did not contain the suggestion image: {html}"
+    );
+
+    let requests = mock_server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+    let listing_ids = body["listing_ids"].as_array().unwrap();
+    let ids: Vec<i64> = listing_ids.iter().map(|v| v.as_i64().unwrap()).collect();
+    assert_eq!(ids, vec![123, 456]);
+}
+
+#[tokio::test]
+async fn test_suggested_stays_link_params_and_encoded_attribution() {
+    let (server, _pool, mock_server, _temp_dir) = setup_test_with_real_templates().await;
+
+    let mock_response = json!({
+        "suggestions": [
+            {
+                "listing_id": 123,
+                "listing_name": "Ocean Loft",
+                "check_in": "2099-09-10",
+                "check_out": "2099-09-13",
+                "nights": 3,
+                "price_total": 200.0,
+                "currency_code": "EUR",
+                "image": null,
+                "person_capacity": 2
+            }
+        ],
+        "degraded": false
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/v1/suggested-stays"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(mock_response))
+        .mount(&mock_server)
+        .await;
+
+    let response = server
+        .get("/.stay?adults=3&children=1&infants=1&utm_source=google&gclid=abc%20123")
+        .add_header("Host", "test.local")
+        .await;
+
+    response.assert_status(StatusCode::OK);
+    let html = response.text();
+    assert!(
+        html.contains("/.stay?from=2099-09-10&to=2099-09-13&adults=3&children=1&infants=1&utm_source=google&gclid=abc%20123"),
+        "rendered HTML did not contain the attributed suggestion link: {html}"
+    );
+}
+
+#[tokio::test]
+async fn test_suggested_stays_degraded_uses_next_availability_and_no_scarcity() {
+    let (server, _pool, mock_server, _temp_dir) = setup_test_with_real_templates().await;
+
+    let mock_response = json!({
+        "suggestions": [
+            {
+                "listing_id": 123,
+                "listing_name": "Beach House",
+                "check_in": "2099-10-01",
+                "check_out": "2099-10-05",
+                "nights": 4,
+                "price_total": 500.0,
+                "currency_code": "EUR",
+                "image": null,
+                "person_capacity": 4
+            }
+        ],
+        "degraded": true
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/v1/suggested-stays"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(mock_response))
+        .mount(&mock_server)
+        .await;
+
+    let response = server.get("/.stay").add_header("Host", "test.local").await;
+
+    response.assert_status(StatusCode::OK);
+    let html = response.text();
+    assert!(html.contains("Next availability"));
+    assert!(!html.contains("Suggested stays"));
+
+    let lower_html = html.to_lowercase();
+    assert!(!lower_html.contains("last room"));
+    assert!(!lower_html.contains("last night"));
+    assert!(!lower_html.contains("hurry"));
+    assert!(!lower_html.contains("only 1 left"));
+}
+
+#[tokio::test]
+async fn test_suggested_stays_empty_suggestions_renders_no_module() {
+    let (server, _pool, mock_server, _temp_dir) = setup_test_with_real_templates().await;
+
+    let mock_response = json!({
+        "suggestions": [],
+        "degraded": false
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/v1/suggested-stays"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(mock_response))
+        .mount(&mock_server)
+        .await;
+
+    let response = server.get("/.stay").add_header("Host", "test.local").await;
+
+    response.assert_status(StatusCode::OK);
+    let html = response.text();
+    assert!(!html.contains("Suggested stays"));
+    assert!(!html.contains("Next availability"));
+}
+
+#[tokio::test]
+async fn test_suggested_stays_api_failure_silently_degrades() {
+    let (server, _pool, mock_server, _temp_dir) = setup_test_with_real_templates().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/suggested-stays"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&mock_server)
+        .await;
+
+    let response = server.get("/.stay").add_header("Host", "test.local").await;
+
+    response.assert_status(StatusCode::OK);
+    let html = response.text();
+    assert!(!html.contains("The booking service is temporarily unavailable"));
+    assert!(!html.contains("Suggested stays"));
+}
+
+#[tokio::test]
+async fn test_dated_request_calls_availability_and_not_suggested_stays() {
+    let (server, _pool, mock_server, _temp_dir) = setup_test().await;
+
+    let mock_avail = json!({
+        "check_in": "2099-01-01",
+        "check_out": "2099-01-05",
+        "nights": 4,
+        "adults": 2,
+        "children": 0,
+        "infants": 0,
+        "results": []
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/v1/availability"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(mock_avail))
+        .mount(&mock_server)
+        .await;
+
+    let response = server
+        .get("/.stay?from=2099-01-01&to=2099-01-05")
+        .add_header("Host", "test.local")
+        .await;
+
+    response.assert_status(StatusCode::OK);
+
+    let requests = mock_server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].url.path(), "/v1/availability");
+}
+
+#[tokio::test]
+async fn test_partial_dates_preserve_normal_form_without_suggestions_call() {
+    let (server, _pool, mock_server, _temp_dir) = setup_test_with_real_templates().await;
+
+    let response = server
+        .get("/.stay?from=2099-01-01")
+        .add_header("Host", "test.local")
+        .await;
+
+    response.assert_status(StatusCode::OK);
+    let html = response.text();
+    assert!(!html.contains("Suggested stays"));
+    assert!(!html.contains("Next availability"));
+
+    let requests = mock_server.received_requests().await.unwrap();
+    assert!(requests.is_empty());
+}
+
+#[tokio::test]
+async fn test_default_visible_dates_are_tomorrow_and_day_after() {
+    let (server, _pool, mock_server, _temp_dir) = setup_test_with_real_templates().await;
+
+    let mock_response = json!({
+        "suggestions": [],
+        "degraded": false
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/v1/suggested-stays"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(mock_response))
+        .mount(&mock_server)
+        .await;
+
+    let response = server.get("/.stay").add_header("Host", "test.local").await;
+
+    response.assert_status(StatusCode::OK);
+    let html = response.text();
+
+    let today = chrono::Utc::now()
+        .with_timezone(&chrono_tz::Indian::Mauritius)
+        .date_naive();
+    let expected_from = (today + chrono::Duration::days(1))
+        .format("%Y-%m-%d")
+        .to_string();
+    let expected_to = (today + chrono::Duration::days(2))
+        .format("%Y-%m-%d")
+        .to_string();
+
+    assert!(html.contains(&format!("value=\"{}\"", expected_from)));
+    assert!(html.contains(&format!("value=\"{}\"", expected_to)));
+}
+
+#[test]
+fn test_suggested_stay_deserialization_nullable_fields() {
+    use doxyde_web::services::sejours_client::SuggestedStaysResponse;
+
+    let json_data = r#"{
+        "suggestions": [
+            {
+                "listing_id": 999,
+                "listing_name": "Unit 999",
+                "check_in": "2026-08-01",
+                "check_out": "2026-08-02",
+                "nights": 1,
+                "price_total": null,
+                "currency_code": null,
+                "image": null,
+                "person_capacity": null
+            }
+        ],
+        "generated_at": "2026-07-23T12:00:00Z",
+        "degraded": true
+    }"#;
+
+    let res: SuggestedStaysResponse =
+        serde_json::from_str(json_data).expect("deserialization failed");
+    assert!(res.degraded);
+    assert_eq!(res.suggestions.len(), 1);
+    let sug = &res.suggestions[0];
+    assert_eq!(sug.listing_id, 999);
+    assert_eq!(sug.check_in, "2026-08-01");
+    assert_eq!(sug.check_out, "2026-08-02");
+    assert_eq!(sug.nights, 1);
+    assert!(sug.price_total.is_none());
+    assert!(sug.currency_code.is_none());
+    assert!(sug.image.is_none());
+    assert!(sug.person_capacity.is_none());
+    assert_eq!(sug.listing_name, "Unit 999");
+}

--- a/templates/booking/stay.html
+++ b/templates/booking/stay.html
@@ -6,6 +6,12 @@
 
 {% block content %}
 <div class="booking-page booking-stay">
+    {% if hero_image %}
+    <div class="booking-stay-hero">
+        <img src="{{ hero_image }}" alt="{{ site_title }}" loading="eager">
+    </div>
+    {% endif %}
+
     <form class="booking-search-bar" action="/.stay" method="GET" toolname="search_stays" tooldescription="Search available stays for given check-in and check-out dates and number of guests (adults, children). Returns a list of available listings with prices.">
         <div class="booking-field">
             <label for="from">{{ labels["booking.checkin"] | default(value="Check-in") }}</label>
@@ -63,6 +69,41 @@
                 {% for r in secondary_results %}{% include "booking/_result_card.html" %}{% endfor %}
             </div>
         {% endif %}
+    {% elif suggestions and suggestions | length > 0 %}
+        <h2 class="booking-section-title">
+            {% if suggested_degraded %}
+                {{ labels["booking.next_availability_title"] | default(value="Next availability") }}
+            {% else %}
+                {{ labels["booking.suggested_title"] | default(value="Suggested stays") }}
+            {% endif %}
+        </h2>
+        <div class="booking-results booking-results-suggested">
+            {% for s in suggestions %}
+            {% set s_url = s.search_url | default(value="/.stay?from=" ~ s.check_in ~ "&to=" ~ s.check_out ~ "&adults=" ~ q_adults ~ "&children=" ~ q_children ~ "&infants=" ~ q_infants ~ utm_qs) %}
+            <div class="booking-card booking-card-clickable" onclick="bkCard(event, '{{ s_url | safe }}')">
+                {% if s.image %}
+                <div class="booking-gallery">
+                    <div class="booking-gallery-track">
+                        <img src="{{ s.image }}" alt="{{ s.listing_name | default(value='') }}" loading="lazy">
+                    </div>
+                </div>
+                {% endif %}
+                <div class="booking-card-head">
+                    <h3 class="booking-card-name">{{ s.listing_name }}</h3>
+                    <div class="booking-card-meta">
+                        {{ s.check_in }} → {{ s.check_out }} · {{ s.nights }} {{ labels["booking.nights"] | default(value="nights") }}
+                        {% if s.person_capacity %} · {{ s.person_capacity }} {{ labels["booking.guests"] | default(value="Guests") }}{% endif %}
+                    </div>
+                </div>
+                {% if s.price_total %}
+                <div class="booking-card-price">
+                    <span class="booking-card-amount">{{ s.price_total }} {{ s.currency_code | default(value='') }}</span>
+                </div>
+                {% endif %}
+                <a class="booking-book-btn" href="{{ s_url | safe }}">{{ labels["booking.check_availability"] | default(value="Check availability") }}</a>
+            </div>
+            {% endfor %}
+        </div>
     {% endif %}
 </div>
 

--- a/templates/styles.css
+++ b/templates/styles.css
@@ -2986,6 +2986,20 @@ footer a:hover {
 /* The stay-search page is wider. Cards keep a consistent size and pack from the
    left, so a sparse result set never leaves a lone stretched card. */
 .booking-page.booking-stay { max-width: 1180px; }
+.booking-stay-hero {
+    width: 100%;
+    height: 220px;
+    border-radius: 12px;
+    overflow: hidden;
+    margin-bottom: 1.5rem;
+    position: relative;
+}
+.booking-stay-hero img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
 .booking-results-primary { grid-template-columns: repeat(auto-fill, minmax(300px, 360px)); justify-content: start; }
 /* Sister-house results stay compact. */
 .booking-results-secondary { grid-template-columns: repeat(auto-fill, minmax(230px, 280px)); justify-content: start; gap: 1rem; }
@@ -2993,8 +3007,9 @@ footer a:hover {
 .booking-results-secondary .booking-gallery-track img { height: 140px; }
 .booking-results-secondary .booking-card-name { font-size: 0.95rem; }
 .booking-results-secondary .booking-card-amount { font-size: 1.1rem; }
+.booking-results-suggested { grid-template-columns: repeat(auto-fill, minmax(280px, 340px)); justify-content: start; }
 @media (max-width: 700px) {
-    .booking-results-primary, .booking-results-secondary { grid-template-columns: 1fr; }
+    .booking-results-primary, .booking-results-secondary, .booking-results-suggested { grid-template-columns: 1fr; }
 }
 
 /* ---- /.book page: Airbnb-style gallery + two-column layout ---- */


### PR DESCRIPTION
## What changed

- adds the `sejours-api` suggested-stays client contract
- renders scoped calendar-gap suggestions on `/.stay` when dates are absent
- preserves attribution parameters in same-site availability links
- adds honest degraded “Next availability” fallback UI, default form dates, and a suggestion-image hero
- repairs pre-existing production panic-safety Clippy violations required by the workspace quality policy

## Impact

Flexible visitors now see real, priced short stays instead of an empty date form. Dated booking searches and reservation behavior remain unchanged.

## Validation

- `cargo check --workspace --all-targets --all-features`
- `cargo fmt --all -- --check`
- general and production panic-safety Clippy gates with warnings denied
- `cargo test --workspace --all-targets --all-features`
- workspace doctests
- release workspace build
- workspace rustdoc with warnings denied
