### PR TITLE
Fix suggested-stay site scope

### DIFF
--- a/doxyde-web/src/handlers/booking.rs
+++ b/doxyde-web/src/handlers/booking.rs
@@ -362,12 +362,16 @@ pub async fn stay_handler(
     }
 
     if !has_dates {
-        let all_ids: Vec<i64> = all.iter().map(|l| l.listing_id).collect();
+        let primary_ids: Vec<i64> = all
+            .iter()
+            .filter(|l| l.role == "primary")
+            .map(|l| l.listing_id)
+            .collect();
         let mut suggestions_json = Vec::new();
         let mut degraded = false;
         let mut hero_image: Option<String> = None;
 
-        match client.suggested_stays(&all_ids, adults, children).await {
+        match client.suggested_stays(&primary_ids, adults, children).await {
             Ok(sug_resp) => {
                 degraded = sug_resp.degraded;
                 let utm_qs = attribution_query(&attr);

--- a/doxyde-web/src/test_helpers.rs
+++ b/doxyde-web/src/test_helpers.rs
@@ -20,10 +20,24 @@ use crate::{autoreload_templates::TemplateEngine, AppState};
 use doxyde_core::models::{session::Session, site::Site, user::User};
 use doxyde_db::repositories::{SessionRepository, UserRepository};
 use sqlx::SqlitePool;
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+
+static TEST_SITES_DIR_ID: AtomicU64 = AtomicU64::new(0);
 
 /// Create a test configuration with sensible defaults
 pub fn create_test_config() -> crate::config::Config {
+    let sites_dir_id = TEST_SITES_DIR_ID.fetch_add(1, Ordering::Relaxed);
+    let sites_directory = std::env::temp_dir()
+        .join(format!(
+            "doxyde-test-sites-{}-{sites_dir_id}",
+            std::process::id()
+        ))
+        .to_string_lossy()
+        .into_owned();
+
     crate::config::Config {
         database_url: "sqlite::memory:".to_string(),
         host: "localhost".to_string(),
@@ -43,8 +57,10 @@ pub fn create_test_config() -> crate::config::Config {
         csrf_header_name: "X-CSRF-Token".to_string(), // Test default
         static_files_max_age: 3600,                   // 1 hour for tests
         oauth_token_expiry: 3600,                     // 1 hour for tests
-        sites_directory: "./test-sites".to_string(),  // Test sites directory
-        multi_site_mode: false,                       // Single database for tests
+        // App-state tests run concurrently and may lazily create a site DB.
+        // Isolate their paths so separate routers cannot race the same migration.
+        sites_directory,
+        multi_site_mode: false, // Single database for tests
         i18n_service_addr: "127.0.0.1:4003".to_string(),
         translation_workers: 4,
         i18n_sync_timeout_ms: 3000,
@@ -407,4 +423,17 @@ pub async fn create_test_session(
         .ok_or_else(|| anyhow::anyhow!("Created session not found"))?;
 
     Ok(session)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::create_test_config;
+
+    #[test]
+    fn test_configs_use_isolated_site_directories() {
+        let first = create_test_config();
+        let second = create_test_config();
+
+        assert_ne!(first.sites_directory, second.sites_directory);
+    }
 }

--- a/doxyde-web/tests/booking_json_tests.rs
+++ b/doxyde-web/tests/booking_json_tests.rs
@@ -505,7 +505,7 @@ async fn setup_test_with_real_templates(
 }
 
 #[tokio::test]
-async fn test_suggested_stays_no_date_calls_api_and_renders_module() {
+async fn test_suggested_stays_no_date_uses_only_primary_site_listings() {
     let (server, pool, mock_server, _temp_dir) = setup_test_with_real_templates().await;
 
     sqlx::query(
@@ -560,7 +560,7 @@ async fn test_suggested_stays_no_date_calls_api_and_renders_module() {
     let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
     let listing_ids = body["listing_ids"].as_array().unwrap();
     let ids: Vec<i64> = listing_ids.iter().map(|v| v.as_i64().unwrap()).collect();
-    assert_eq!(ids, vec![123, 456]);
+    assert_eq!(ids, vec![123]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- restrict no-date stay suggestions to the site primary listing set
- keep secondary sister-property listings out of merchandising cards
- isolate app-state test databases to remove concurrent SQLite migration races

## Verification
- full Rust workspace quality matrix passes with all targets and all features
- production API smoke confirms Twakila and Rusty Pelican primary scopes return disjoint listing IDs